### PR TITLE
Remove CrossOrigin-Allow-All annotation from endpoints

### DIFF
--- a/data-service-backend/src/main/java/ch/akros/marketplace/dataservice/controller/DeleteTopicController.java
+++ b/data-service-backend/src/main/java/ch/akros/marketplace/dataservice/controller/DeleteTopicController.java
@@ -12,7 +12,6 @@ import ch.akros.marketplace.dataservice.service.TopicService;
 import lombok.extern.slf4j.Slf4j;
 
 @RestController
-@CrossOrigin(origins = "*", allowedHeaders = "*")
 @Slf4j
 public class DeleteTopicController implements DeleteTopicApi {
   @Autowired

--- a/data-service-backend/src/main/java/ch/akros/marketplace/dataservice/controller/ListCategoriesController.java
+++ b/data-service-backend/src/main/java/ch/akros/marketplace/dataservice/controller/ListCategoriesController.java
@@ -15,7 +15,6 @@ import ch.akros.marketplace.dataservice.service.CategoryService;
 import lombok.extern.slf4j.Slf4j;
 
 @RestController
-@CrossOrigin(origins = "*", allowedHeaders = "*")
 @Slf4j
 public class ListCategoriesController implements ListCategoriesApi {
   @Autowired

--- a/data-service-backend/src/main/java/ch/akros/marketplace/dataservice/controller/ListCategorySearchFieldTypesController.java
+++ b/data-service-backend/src/main/java/ch/akros/marketplace/dataservice/controller/ListCategorySearchFieldTypesController.java
@@ -15,7 +15,6 @@ import ch.akros.marketplace.dataservice.service.CategoryService;
 import lombok.extern.slf4j.Slf4j;
 
 @RestController
-@CrossOrigin(origins = "*", allowedHeaders = "*")
 @Slf4j
 public class ListCategorySearchFieldTypesController implements ListCategorySearchFieldTypesApi {
   @Autowired

--- a/data-service-backend/src/main/java/ch/akros/marketplace/dataservice/controller/ListFieldTypeDefinitionsController.java
+++ b/data-service-backend/src/main/java/ch/akros/marketplace/dataservice/controller/ListFieldTypeDefinitionsController.java
@@ -15,7 +15,6 @@ import ch.akros.marketplace.dataservice.service.FieldTypeDefinitionService;
 import lombok.extern.slf4j.Slf4j;
 
 @RestController
-@CrossOrigin(origins = "*", allowedHeaders = "*")
 @Slf4j
 public class ListFieldTypeDefinitionsController implements ListFieldTypeDefinitionApi {
   @Autowired

--- a/data-service-backend/src/main/java/ch/akros/marketplace/dataservice/controller/ListTopicFieldTypesController.java
+++ b/data-service-backend/src/main/java/ch/akros/marketplace/dataservice/controller/ListTopicFieldTypesController.java
@@ -15,7 +15,6 @@ import ch.akros.marketplace.dataservice.service.TopicService;
 import lombok.extern.slf4j.Slf4j;
 
 @RestController
-@CrossOrigin(origins = "*", allowedHeaders = "*")
 @Slf4j
 public class ListTopicFieldTypesController implements ListTopicFieldTypesApi {
   @Autowired

--- a/data-service-backend/src/main/java/ch/akros/marketplace/dataservice/controller/LoadTopicController.java
+++ b/data-service-backend/src/main/java/ch/akros/marketplace/dataservice/controller/LoadTopicController.java
@@ -13,7 +13,6 @@ import ch.akros.marketplace.dataservice.service.TopicService;
 import lombok.extern.slf4j.Slf4j;
 
 @RestController
-@CrossOrigin(origins = "*", allowedHeaders = "*")
 @Slf4j
 public class LoadTopicController implements LoadTopicApi {
   @Autowired

--- a/data-service-backend/src/main/java/ch/akros/marketplace/dataservice/controller/SaveTopicController.java
+++ b/data-service-backend/src/main/java/ch/akros/marketplace/dataservice/controller/SaveTopicController.java
@@ -13,7 +13,6 @@ import ch.akros.marketplace.dataservice.service.TopicService;
 import lombok.extern.slf4j.Slf4j;
 
 @RestController
-@CrossOrigin(origins = "*", allowedHeaders = "*")
 @Slf4j
 public class SaveTopicController implements SaveTopicApi {
   @Autowired

--- a/data-service-backend/src/main/java/ch/akros/marketplace/dataservice/controller/SearchTopicController.java
+++ b/data-service-backend/src/main/java/ch/akros/marketplace/dataservice/controller/SearchTopicController.java
@@ -14,7 +14,6 @@ import ch.akros.marketplace.dataservice.service.TopicService;
 import lombok.extern.slf4j.Slf4j;
 
 @RestController
-@CrossOrigin(origins = "*", allowedHeaders = "*")
 @Slf4j
 public class SearchTopicController implements SearchTopicApi {
   @Autowired


### PR DESCRIPTION
This PR removes every CrossOrigin headers for the REST-Endpoints. Allowing every origin is a security issue and only allowing certain origins is configuration overhead. The backend won't need to worry about CORS anymore because the frontend will run with a reverse proxy that reroutes any request to the API with the correct origin.